### PR TITLE
Bump sbt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk: oraclejdk8
 before_script:
  - export JVM_OPTS="-Dfile.encoding=UTF-8 -Xmx1G -Xms1G -server -XX:ReservedCodeCacheSize=128M"
 
-script: /usr/bin/sbt scripted
+script: sbt scripted
 
 # Undo _JAVA_OPTIONS environment variable
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,13 @@
 dist: trusty
 group: stable
 
-language: ruby
+language: scala
 jdk: oraclejdk8
 
 before_script:
  - export JVM_OPTS="-Dfile.encoding=UTF-8 -Xmx1G -Xms1G -server -XX:ReservedCodeCacheSize=128M"
 
 script: /usr/bin/sbt scripted
-
-addons:
-  apt:
-    sources:
-      - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
-      - key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=sbt'
-    packages:
-      - sbt=1.2.8
 
 # Undo _JAVA_OPTIONS environment variable
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
       - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
       - key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=sbt'
     packages:
-      - sbt=1.1.6
+      - sbt=1.2.8
 
 # Undo _JAVA_OPTIONS environment variable
 before_script:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0-M1
+sbt.version=1.2.8


### PR DESCRIPTION
Fixes #6

Instead of using `apt` addon to install sbt, this PR replaces image with `scala` which have sbt installed.
If changing language have some issue, I am happy to fix just wrong `key_url` position.