### PR TITLE
implement secondary match

### DIFF
--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -163,6 +163,9 @@ object ProjectMatrix {
     def isMatch(that: ProjectRow): Boolean =
       VirtualAxis.isMatch(this.axisValues, that.axisValues)
 
+    def isSecondaryMatch(that: ProjectRow): Boolean =
+      VirtualAxis.isSecondaryMatch(this.axisValues, that.axisValues)
+
     override def toString: String = s"ProjectRow($autoScalaLibrary, $axisValues)"
   }
 
@@ -275,7 +278,8 @@ object ProjectMatrix {
 
     // resolve to the closest match for the given row
     private[sbt] def resolveMatch(thatRow: ProjectRow): ProjectReference =
-      rows.find(r => r.isMatch(thatRow)) match {
+      (rows.find(r => r.isMatch(thatRow)) orElse
+        rows.find(r => r.isSecondaryMatch(thatRow))) match {
         case Some(r) => LocalProject(resolveProjectIds(r))
         case _       => sys.error(s"no rows were found in $id matching $thatRow: $rows")
       }

--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -249,7 +249,8 @@ object ProjectMatrix {
             crossTarget := Keys.target.value,
             sourceDirectory := base.getAbsoluteFile / "src",
             inConfig(Compile)(makeSources(nonScalaDirSuffix, svDirSuffix)),
-            inConfig(Test)(makeSources(nonScalaDirSuffix, svDirSuffix))
+            inConfig(Test)(makeSources(nonScalaDirSuffix, svDirSuffix)),
+            projectDependencies := projectDependenciesTask.value,
           )
           .settings(self.settings)
           .configure(transforms: _*)
@@ -258,6 +259,43 @@ object ProjectMatrix {
       }): _*)
     }
 
+  // backport of https://github.com/sbt/sbt/pull/5767
+  def projectDependenciesTask: Def.Initialize[Task[Seq[ModuleID]]] =
+    Def.task {
+      val orig = projectDependencies.value
+      val sbv = scalaBinaryVersion.value
+      val ref = thisProjectRef.value
+      val data = settingsData.value
+      val deps = buildDependencies.value
+      val sbtV = VersionNumber(sbtVersion.value)
+
+      if (sbtV._1.getOrElse(0L) == 1 && (sbtV._2.getOrElse(0L) < 4)) {
+        deps.classpath(ref) flatMap { dep =>
+          val depProjIdOpt = (dep.project / projectID).get(data)
+          val depSVOpt = (dep.project / scalaVersion).get(data)
+          val depSBVOpt = (dep.project / scalaBinaryVersion).get(data)
+          val depCrossOpt = (dep.project / crossVersion).get(data)
+          (depProjIdOpt, depSVOpt, depSBVOpt, depCrossOpt) match {
+            case (Some(depProjId), Some(depSV), Some(depSBV), Some(depCross)) =>
+              if (sbv == depSBV || depCross != CrossVersion.binary)
+                Some(
+                  depProjId.withConfigurations(dep.configuration).withExplicitArtifacts(Vector.empty)
+                )
+              else if (VirtualAxis.isScala2Scala3Sandwich(sbv, depSBV) && depCross == CrossVersion.binary)
+                Some(
+                  depProjId
+                    .withCrossVersion(CrossVersion.constant(depSBV))
+                    .withConfigurations(dep.configuration)
+                    .withExplicitArtifacts(Vector.empty)
+                )
+              else sys.error(s"scalaBinaryVersion mismatch: expected $sbv but found ${depSBV}")
+            case _ => None
+          }
+        }
+      } else {
+        orig
+      }
+    }
 
     override lazy val componentProjects: Seq[Project] = resolvedMappings.values.toList
 

--- a/src/sbt-test/projectMatrix/jvm-sandwich/bar-app/D.scala
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/bar-app/D.scala
@@ -1,0 +1,5 @@
+package example
+
+object D {
+  val x = C.x
+}

--- a/src/sbt-test/projectMatrix/jvm-sandwich/bar-core/C.scala
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/bar-core/C.scala
@@ -1,0 +1,5 @@
+package example
+
+object C {
+  val x = 1
+}

--- a/src/sbt-test/projectMatrix/jvm-sandwich/baz-app/F.scala
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/baz-app/F.scala
@@ -1,0 +1,5 @@
+package example
+
+object F {
+  val x = E.x
+}

--- a/src/sbt-test/projectMatrix/jvm-sandwich/baz-core/E.scala
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/baz-core/E.scala
@@ -1,0 +1,5 @@
+package example
+
+object E {
+  val x = 1
+}

--- a/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
@@ -1,0 +1,17 @@
+val dottyVersion = "0.23.0"
+ThisBuild / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
+// TODO use 2.13.4 when it's out
+lazy val scala213 = "2.13.4-bin-aeee8f0"
+
+lazy val fooApp = (projectMatrix in file("foo-app"))
+  .dependsOn(fooCore)
+  .settings(
+    name := "app",
+  )
+  .jvmPlatform(scalaVersions = Seq(dottyVersion))
+
+lazy val fooCore = (projectMatrix in file("foo-core"))
+  .settings(
+    name := "core",
+  )
+  .jvmPlatform(scalaVersions = Seq("2.13.3", "2.12.12"))

--- a/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
@@ -1,3 +1,5 @@
+lazy val check = taskKey[Unit]("")
+
 val dottyVersion = "0.23.0"
 ThisBuild / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
 // TODO use 2.13.4 when it's out
@@ -6,12 +8,47 @@ lazy val scala213 = "2.13.4-bin-aeee8f0"
 lazy val fooApp = (projectMatrix in file("foo-app"))
   .dependsOn(fooCore)
   .settings(
-    name := "app",
+    name := "foo app",
   )
   .jvmPlatform(scalaVersions = Seq(dottyVersion))
 
 lazy val fooCore = (projectMatrix in file("foo-core"))
   .settings(
-    name := "core",
+    name := "foo core",
   )
-  .jvmPlatform(scalaVersions = Seq("2.13.3", "2.12.12"))
+  .jvmPlatform(scalaVersions = Seq(scala213, "2.12.12"))
+
+lazy val barApp = (projectMatrix in file("bar-app"))
+  .dependsOn(barCore)
+  .settings(
+    name := "bar app",
+  )
+  .jvmPlatform(scalaVersions = Seq(scala213))
+
+lazy val barCore = (projectMatrix in file("bar-core"))
+  .settings(
+    name := "bar core",
+  )
+  .jvmPlatform(scalaVersions = Seq(dottyVersion))
+
+// choose 2.13 when bazCore offers both 2.13 and Dotty
+lazy val bazApp = (projectMatrix in file("baz-app"))
+  .dependsOn(bazCore)
+  .settings(
+    name := "baz app",
+    check := {
+      val cp = (Compile / fullClasspath).value
+        .map(_.data.getName)
+
+      assert(cp.contains("baz-core_2.13-0.1.0-SNAPSHOT.jar"), s"$cp")
+      assert(!cp.contains("baz-core_0.23-0.1.0-SNAPSHOT.jar"), s"$cp")
+    },
+  )
+  .jvmPlatform(scalaVersions = Seq(scala213))
+
+lazy val bazCore = (projectMatrix in file("baz-core"))
+  .settings(
+    name := "baz core",
+    exportJars := true,
+  )
+  .jvmPlatform(scalaVersions = Seq(scala213, dottyVersion))

--- a/src/sbt-test/projectMatrix/jvm-sandwich/foo-app/B.scala
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/foo-app/B.scala
@@ -1,0 +1,5 @@
+package example
+
+object B {
+  val x = A.x
+}

--- a/src/sbt-test/projectMatrix/jvm-sandwich/foo-core/A.scala
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/foo-core/A.scala
@@ -1,0 +1,5 @@
+package example
+
+object A {
+  val x = 1
+}

--- a/src/sbt-test/projectMatrix/jvm-sandwich/project/build.properties
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.13

--- a/src/sbt-test/projectMatrix/jvm-sandwich/project/plugins.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/project/plugins.sbt
@@ -1,0 +1,6 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")

--- a/src/sbt-test/projectMatrix/jvm-sandwich/test
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/test
@@ -1,0 +1,2 @@
+> fooAppJVM0_23/compile
+

--- a/src/sbt-test/projectMatrix/jvm-sandwich/test
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/test
@@ -1,2 +1,5 @@
 > fooAppJVM0_23/compile
 
+> barAppJVM2_13/compile
+
+> bazAppJVM2_13/check


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-projectmatrix/issues/28

When the matching scalaVersion is available it would select it, but when it isn't this adds the ability to fall back to anScala 2.13-3.x sandwich compatible version.