### PR TITLE
treat JVM and 2.13 as default axis

### DIFF
--- a/src/main/scala/sbt/VirtualAxis.scala
+++ b/src/main/scala/sbt/VirtualAxis.scala
@@ -69,6 +69,15 @@ object VirtualAxis {
     compare(sbv1, sbv2) || compare(sbv2, sbv1)
   }
 
+  // This admits partial Scala version
+  private[sbt] def isPartialVersionEquals(ax1: VirtualAxis, ax2: VirtualAxis): Boolean = {
+    (ax1, ax2) match {
+      case (ax1: ScalaVersionAxis, ax2: ScalaVersionAxis) =>
+        (ax1 == ax2) || (ax1.value == ax2.value)
+      case _ => ax1 == ax2
+    }
+  }
+
   case class ScalaVersionAxis(scalaVersion: String, value: String) extends WeakAxis {
     override def idSuffix: String = directorySuffix.replaceAll("""\W+""", "_")
     override val suffixOrder: Int = 100

--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -112,6 +112,8 @@ sealed trait ProjectMatrix extends CompositeProject {
   def nativePlatform(scalaVersions: Seq[String], settings: Seq[Setting[_]]): ProjectMatrix
   def native: ProjectFinder
 
+  def defaultAxes(axes: VirtualAxis*): ProjectMatrix
+
   def projectRefs: Seq[ProjectReference]
 
   def filterProjects(axisValues: Seq[VirtualAxis]): Seq[Project]
@@ -193,6 +195,7 @@ object ProjectMatrix {
       val configurations: Seq[Configuration],
       val plugins: Plugins,
       val transforms: Seq[Project => Project],
+      val defAxes: Seq[VirtualAxis],
   ) extends ProjectMatrix { self =>
     lazy val resolvedMappings: ListMap[ProjectRow, Project] = resolveMappings
     private def resolveProjectIds: Map[ProjectRow, String] = {
@@ -200,11 +203,15 @@ object ProjectMatrix {
         r <- rows
       } yield {
         val axes = r.axisValues.sortBy(_.suffixOrder)
+          .filterNot(isSortOfDefaultAxis)
         val idSuffix = axes.map(_.idSuffix).mkString("")
         val childId = self.id + idSuffix
         r -> childId
       }): _*)
     }
+
+    private def isSortOfDefaultAxis(a: VirtualAxis): Boolean =
+      defAxes exists { da => VirtualAxis.isPartialVersionEquals(da, a) }
 
     private def resolveMappings: ListMap[ProjectRow, Project] = {
       val projectIds = resolveProjectIds
@@ -282,7 +289,8 @@ object ProjectMatrix {
             case (Some(depProjId), Some(depSV), Some(depSBV), Some(depCross)) =>
               if (sbv == depSBV || depCross != CrossVersion.binary)
                 Some(
-                  depProjId.withConfigurations(dep.configuration).withExplicitArtifacts(Vector.empty)
+                  depProjId.withConfigurations(dep.configuration)
+                    .withExplicitArtifacts(Vector.empty)
                 )
               else if (VirtualAxis.isScala2Scala3Sandwich(sbv, depSBV) && depCross == CrossVersion.binary)
                 Some(
@@ -291,7 +299,7 @@ object ProjectMatrix {
                     .withConfigurations(dep.configuration)
                     .withExplicitArtifacts(Vector.empty)
                 )
-              else sys.error(s"scalaBinaryVersion mismatch: expected $sbv but found ${depSBV}")
+              else sys.error(s"scalaBinaryVersion mismatch: expected $sbv but found ${depSBV} in $depProjId")
             case _ => None
           }
         }
@@ -384,6 +392,9 @@ object ProjectMatrix {
             ))
             .settings(settings)
         })
+
+    override def defaultAxes(axes: VirtualAxis*): ProjectMatrix =
+      copy(defAxes = axes.toSeq)
 
     def scalajsPlugin(classLoader: ClassLoader): Try[AutoPlugin] = {
       import sbtprojectmatrix.ReflectionUtil._
@@ -494,6 +505,7 @@ object ProjectMatrix {
         configurations: Seq[Configuration] = configurations,
         plugins: Plugins = plugins,
         transforms: Seq[Project => Project] = transforms,
+        defAxes: Seq[VirtualAxis] = defAxes,
     ): ProjectMatrix = {
       val matrix = unresolved(
         id,
@@ -505,7 +517,8 @@ object ProjectMatrix {
         settings,
         configurations,
         plugins,
-        transforms
+        transforms,
+        defAxes,
       )
       allMatrices(id) = matrix
       matrix
@@ -514,7 +527,8 @@ object ProjectMatrix {
 
   // called by macro
   def apply(id: String, base: sbt.File): ProjectMatrix = {
-    val matrix = unresolved(id, base, Nil, Nil, Nil, Nil, Nil, Nil, Plugins.Empty, Nil)
+    val defaultDefAxes = Seq(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion("2.13.3"))
+    val matrix = unresolved(id, base, Nil, Nil, Nil, Nil, Nil, Nil, Plugins.Empty, Nil, defaultDefAxes)
     allMatrices(id) = matrix
     matrix
   }
@@ -529,7 +543,8 @@ object ProjectMatrix {
       settings: Seq[Def.Setting[_]],
       configurations: Seq[Configuration],
       plugins: Plugins,
-      transforms: Seq[Project => Project]
+      transforms: Seq[Project => Project],
+      defAxes: Seq[VirtualAxis],
   ): ProjectMatrix =
     new ProjectMatrixDef(
       id,
@@ -541,7 +556,8 @@ object ProjectMatrix {
       settings,
       configurations,
       plugins,
-      transforms
+      transforms,
+      defAxes,
     )
 
   def lookupMatrix(local: LocalProjectMatrix): ProjectMatrix = {

--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -240,8 +240,11 @@ object ProjectMatrix {
             name := self.id
           )
           .settings(
-            r.scalaVersionOpt.toList map { sv =>
-              Keys.scalaVersion := sv
+            r.scalaVersionOpt match {
+              case Some(sv) =>
+                List(Keys.scalaVersion := sv)
+              case _ =>
+                List(Keys.autoScalaLibrary := false, Keys.crossPaths := false)
             }
           )
           .settings(

--- a/src/sbt-test/projectMatrix/jvm-sandwich/test
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/test
@@ -1,5 +1,5 @@
-> fooAppJVM0_23/compile
+> fooApp0_23/compile
 
-> barAppJVM2_13/compile
+> barApp/compile
 
-> bazAppJVM2_13/check
+> bazApp/check

--- a/src/sbt-test/projectMatrix/jvm-with-scoping/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-with-scoping/build.sbt
@@ -1,3 +1,5 @@
+lazy val scala213 = "2.13.3"
+lazy val scala212 = "2.12.12"
 lazy val check = taskKey[Unit]("")
 
 lazy val root = (project in file("."))
@@ -11,7 +13,7 @@ lazy val app = (projectMatrix in file("app"))
   .settings(
     name := "app"
   )
-  .jvmPlatform(scalaVersions = Seq("2.12.8"))
+  .jvmPlatform(scalaVersions = Seq(scala213))
 
 lazy val core = (projectMatrix in file("core"))
   .settings(
@@ -22,7 +24,7 @@ lazy val core = (projectMatrix in file("core"))
       assert(directs.size == 2, s"$directs")
     },
   )
-  .jvmPlatform(scalaVersions = Seq("2.12.8", "2.11.12"))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala212))
   .configure(addStuff)
 
 lazy val intf = (projectMatrix in file("intf"))
@@ -33,7 +35,7 @@ lazy val intf = (projectMatrix in file("intf"))
   )
   .jvmPlatform(autoScalaLibrary = false)
 
-lazy val core212 = core.jvm("2.12.8")
+lazy val core213 = core.jvm(scala213)
 
 def addStuff(p: Project): Project = {
   p.settings(

--- a/src/sbt-test/projectMatrix/jvm-with-scoping/test
+++ b/src/sbt-test/projectMatrix/jvm-with-scoping/test
@@ -1,6 +1,6 @@
 > compile
 
+$ exists core/target/jvm-2.13/classes/a/Core.class
 $ exists core/target/jvm-2.12/classes/a/Core.class
-$ exists core/target/jvm-2.11/classes/a/Core.class
 
-> coreJVM2_12/check
+> core/check

--- a/src/sbt-test/projectMatrix/jvm/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm/build.sbt
@@ -1,3 +1,5 @@
+lazy val scala213 = "2.13.3"
+lazy val scala212 = "2.12.12"
 lazy val check = taskKey[Unit]("")
 
 lazy val root = (project in file("."))
@@ -11,7 +13,7 @@ lazy val app = (projectMatrix in file("app"))
   .settings(
     name := "app"
   )
-  .jvmPlatform(scalaVersions = Seq("2.12.8"))
+  .jvmPlatform(scalaVersions = Seq(scala213))
 
 lazy val core = (projectMatrix in file("core"))
   .settings(
@@ -19,7 +21,7 @@ lazy val core = (projectMatrix in file("core"))
       assert(moduleName.value == "core", s"moduleName is ${moduleName.value}")
     },
   )
-  .jvmPlatform(scalaVersions = Seq("2.12.8", "2.11.12"))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala212))
 
 lazy val intf = (projectMatrix in file("intf"))
   .settings(
@@ -29,4 +31,4 @@ lazy val intf = (projectMatrix in file("intf"))
   )
   .jvmPlatform(autoScalaLibrary = false)
 
-lazy val core212 = core.jvm("2.12.8")
+lazy val core213 = core.jvm(scala213)

--- a/src/sbt-test/projectMatrix/jvm/test
+++ b/src/sbt-test/projectMatrix/jvm/test
@@ -1,6 +1,6 @@
 > compile
 
+$ exists core/target/jvm-2.13/classes/a/Core.class
 $ exists core/target/jvm-2.12/classes/a/Core.class
-$ exists core/target/jvm-2.11/classes/a/Core.class
 
-> coreJVM2_12/check
+> core/check


### PR DESCRIPTION
By default, JVM and Scala 2.13 are treated default axes so the suffixes won't show up as project id. This allows the build user to refer to the subproject using `core` as opposed to `coreJVM2_13`.