### PR TITLE
Use Scala's ABI version to generate suffix

### DIFF
--- a/src/main/scala/sbt/VirtualAxis.scala
+++ b/src/main/scala/sbt/VirtualAxis.scala
@@ -1,6 +1,6 @@
 package sbt
 
-import sbt.librarymanagement.CrossVersion.partialVersion
+import sbt.librarymanagement.CrossVersion.{ binaryScalaVersion, partialVersion }
 
 /** Virtual Axis represents a parameter to a project matrix row. */
 sealed abstract class VirtualAxis {
@@ -106,6 +106,9 @@ object VirtualAxis {
       case Some((m, n)) => scalaVersionAxis(scalaVersion, s"$m.$n")
       case _            => scalaVersionAxis(scalaVersion, scalaVersion)
     }
+  def scalaABIVersion(scalaVersion: String): ScalaVersionAxis =
+    scalaVersionAxis(scalaVersion, binaryScalaVersion(scalaVersion))
+
   def scalaVersionAxis(scalaVersion: String, value: String) =
     ScalaVersionAxis(scalaVersion, value)
 

--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -434,7 +434,7 @@ object ProjectMatrix {
     private final class AxisBaseProjectFinder(axisValues: Seq[VirtualAxis]) extends ProjectFinder {
       def get: Seq[Project] = filterProjects(axisValues)
       def apply(sv: String): Project =
-        filterProjects(true, axisValues ++ Seq(VirtualAxis.scalaPartialVersion(sv))).headOption
+        filterProjects(true, axisValues ++ Seq(VirtualAxis.scalaABIVersion(sv))).headOption
         .getOrElse(sys.error(s"project matching $axisValues and $sv was not found"))
       def apply(autoScalaLibrary: Boolean): Project =
         filterProjects(autoScalaLibrary, axisValues).headOption
@@ -467,7 +467,7 @@ object ProjectMatrix {
     ): ProjectMatrix =
       if (autoScalaLibrary) {
         scalaVersions.foldLeft(this: ProjectMatrix) { (acc, sv) =>
-          acc.customRow(autoScalaLibrary, axisValues ++ Seq(VirtualAxis.scalaPartialVersion(sv)), process)
+          acc.customRow(autoScalaLibrary, axisValues ++ Seq(VirtualAxis.scalaABIVersion(sv)), process)
         }
       } else {
         customRow(autoScalaLibrary, Seq(VirtualAxis.jvm), process)
@@ -518,7 +518,7 @@ object ProjectMatrix {
 
   // called by macro
   def apply(id: String, base: sbt.File): ProjectMatrix = {
-    val defaultDefAxes = Seq(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion("2.13.3"))
+    val defaultDefAxes = Seq(VirtualAxis.jvm, VirtualAxis.scalaABIVersion("2.13.3"))
     val matrix = unresolved(id, base, Nil, Nil, Nil, Nil, Nil, Nil, Plugins.Empty, Nil, defaultDefAxes)
     allMatrices(id) = matrix
     matrix

--- a/src/sbt-test/projectMatrix/jvm-sandwich-sbt-1.3/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich-sbt-1.3/build.sbt
@@ -1,16 +1,18 @@
 lazy val check = taskKey[Unit]("")
-
-val dottyVersion = "3.0.0-M1"
-ThisBuild / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
-// TODO use 2.13.4 when it's out
-lazy val scala213 = "2.13.4-bin-aeee8f0"
+lazy val scala3 = "3.0.0-M1"
+lazy val scala213 = "2.13.4"
 
 lazy val fooApp = (projectMatrix in file("foo-app"))
   .dependsOn(fooCore)
   .settings(
     name := "foo app",
   )
-  .jvmPlatform(scalaVersions = Seq(dottyVersion))
+  .jvmPlatform(scalaVersions = Seq(scala3))
+
+lazy val fooApp3 = fooApp.jvm(scala3)
+  .settings(
+    test := { () },
+  )
 
 lazy val fooCore = (projectMatrix in file("foo-core"))
   .settings(
@@ -29,7 +31,7 @@ lazy val barCore = (projectMatrix in file("bar-core"))
   .settings(
     name := "bar core",
   )
-  .jvmPlatform(scalaVersions = Seq(dottyVersion))
+  .jvmPlatform(scalaVersions = Seq(scala3))
 
 // choose 2.13 when bazCore offers both 2.13 and Dotty
 lazy val bazApp = (projectMatrix in file("baz-app"))
@@ -51,4 +53,4 @@ lazy val bazCore = (projectMatrix in file("baz-core"))
     name := "baz core",
     exportJars := true,
   )
-  .jvmPlatform(scalaVersions = Seq(scala213, dottyVersion))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala3))

--- a/src/sbt-test/projectMatrix/jvm-sandwich-sbt-1.3/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich-sbt-1.3/build.sbt
@@ -1,5 +1,6 @@
 lazy val check = taskKey[Unit]("")
-lazy val scala3 = "3.0.0-M1"
+lazy val scala3M1 = "3.0.0-M1"
+lazy val scala3M2 = "3.0.0-M2"
 lazy val scala213 = "2.13.4"
 
 lazy val fooApp = (projectMatrix in file("foo-app"))
@@ -7,9 +8,9 @@ lazy val fooApp = (projectMatrix in file("foo-app"))
   .settings(
     name := "foo app",
   )
-  .jvmPlatform(scalaVersions = Seq(scala3))
+  .jvmPlatform(scalaVersions = Seq(scala3M1, scala3M2))
 
-lazy val fooApp3 = fooApp.jvm(scala3)
+lazy val fooApp3 = fooApp.jvm(scala3M1)
   .settings(
     test := { () },
   )
@@ -31,7 +32,7 @@ lazy val barCore = (projectMatrix in file("bar-core"))
   .settings(
     name := "bar core",
   )
-  .jvmPlatform(scalaVersions = Seq(scala3))
+  .jvmPlatform(scalaVersions = Seq(scala3M2))
 
 // choose 2.13 when bazCore offers both 2.13 and Dotty
 lazy val bazApp = (projectMatrix in file("baz-app"))
@@ -53,4 +54,4 @@ lazy val bazCore = (projectMatrix in file("baz-core"))
     name := "baz core",
     exportJars := true,
   )
-  .jvmPlatform(scalaVersions = Seq(scala213, scala3))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala3M1))

--- a/src/sbt-test/projectMatrix/jvm-sandwich-sbt-1.3/test
+++ b/src/sbt-test/projectMatrix/jvm-sandwich-sbt-1.3/test
@@ -1,4 +1,6 @@
-> fooApp3_0/compile
+> projects
+
+> fooApp3_0_0_M1/compile
 
 > barApp/compile
 

--- a/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
@@ -1,5 +1,6 @@
 lazy val check = taskKey[Unit]("")
-lazy val scala3 = "3.0.0-M1"
+lazy val scala3M1 = "3.0.0-M1"
+lazy val scala3M2 = "3.0.0-M2"
 lazy val scala213 = "2.13.4"
 
 lazy val fooApp = (projectMatrix in file("foo-app"))
@@ -7,7 +8,7 @@ lazy val fooApp = (projectMatrix in file("foo-app"))
   .settings(
     name := "foo app",
   )
-  .jvmPlatform(scalaVersions = Seq(scala3))
+  .jvmPlatform(scalaVersions = Seq(scala3M1, scala3M2))
 
 lazy val fooCore = (projectMatrix in file("foo-core"))
   .settings(
@@ -26,7 +27,7 @@ lazy val barCore = (projectMatrix in file("bar-core"))
   .settings(
     name := "bar core",
   )
-  .jvmPlatform(scalaVersions = Seq(scala3))
+  .jvmPlatform(scalaVersions = Seq(scala3M1))
 
 // choose 2.13 when bazCore offers both 2.13 and Dotty
 lazy val bazApp = (projectMatrix in file("baz-app"))
@@ -49,4 +50,4 @@ lazy val bazCore = (projectMatrix in file("baz-core"))
     name := "baz core",
     exportJars := true,
   )
-  .jvmPlatform(scalaVersions = Seq(scala213, scala3))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala3M1, scala3M2))

--- a/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/build.sbt
@@ -1,16 +1,13 @@
 lazy val check = taskKey[Unit]("")
-
-val dottyVersion = "3.0.0-M1"
-ThisBuild / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
-// TODO use 2.13.4 when it's out
-lazy val scala213 = "2.13.4-bin-aeee8f0"
+lazy val scala3 = "3.0.0-M1"
+lazy val scala213 = "2.13.4"
 
 lazy val fooApp = (projectMatrix in file("foo-app"))
   .dependsOn(fooCore)
   .settings(
     name := "foo app",
   )
-  .jvmPlatform(scalaVersions = Seq(dottyVersion))
+  .jvmPlatform(scalaVersions = Seq(scala3))
 
 lazy val fooCore = (projectMatrix in file("foo-core"))
   .settings(
@@ -29,7 +26,7 @@ lazy val barCore = (projectMatrix in file("bar-core"))
   .settings(
     name := "bar core",
   )
-  .jvmPlatform(scalaVersions = Seq(dottyVersion))
+  .jvmPlatform(scalaVersions = Seq(scala3))
 
 // choose 2.13 when bazCore offers both 2.13 and Dotty
 lazy val bazApp = (projectMatrix in file("baz-app"))
@@ -52,4 +49,4 @@ lazy val bazCore = (projectMatrix in file("baz-core"))
     name := "baz core",
     exportJars := true,
   )
-  .jvmPlatform(scalaVersions = Seq(scala213, dottyVersion))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala3))

--- a/src/sbt-test/projectMatrix/jvm-sandwich/test
+++ b/src/sbt-test/projectMatrix/jvm-sandwich/test
@@ -1,4 +1,6 @@
-> fooApp3_0/compile
+> projects
+
+> fooApp3_0_0_M1/compile
 
 > barApp/compile
 


### PR DESCRIPTION
Fixes #37

To support cross building of 3.0.0-M1 and 3.0.0-M2, use the ABI version to generate the subproject suffix instead of the partial version (first two segments)