### PR TITLE
Add homepage setting to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ ThisBuild / version := {
   else orig
 }
 ThisBuild / description  := "sbt plugin to define project matrix for cross building"
+ThisBuild / homepage     := Some(url("https://github.com/sbt/sbt-projectmatrix")),
 ThisBuild / licenses     := Seq("MIT License" -> url("https://github.com/sbt/sbt-projectmatrix/blob/master/LICENSE"))
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / version := {
   else orig
 }
 ThisBuild / description  := "sbt plugin to define project matrix for cross building"
-ThisBuild / homepage     := Some(url("https://github.com/sbt/sbt-projectmatrix")),
+ThisBuild / homepage     := Some(url("https://github.com/sbt/sbt-projectmatrix"))
 ThisBuild / licenses     := Seq("MIT License" -> url("https://github.com/sbt/sbt-projectmatrix/blob/master/LICENSE"))
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
This enables Scala Steward to link to this page, the GitHub release notes
and version diff in its pull requests.