### PR TITLE
Inner class WeakAxis

### DIFF
--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -321,7 +321,7 @@ object ProjectMatrix {
       (rows.find(r => r.isMatch(thatRow)) orElse
         rows.find(r => r.isSecondaryMatch(thatRow))) match {
         case Some(r) => LocalProject(resolveProjectIds(r))
-        case _       => sys.error(s"no rows were found in $id matching $thatRow: $rows")
+        case _       => sys.error(s"no rows were found in $id matching $thatRow:\n${rows.mkString("\n")}")
       }
 
     private def makeSources(dirSuffix: String, svDirSuffix: String): Setting[_] = {

--- a/src/sbt-test/projectMatrix/jvm-inner-class/build.sbt
+++ b/src/sbt-test/projectMatrix/jvm-inner-class/build.sbt
@@ -1,0 +1,44 @@
+import sbt.{Def, VirtualAxis}
+import sbtprojectmatrix.ProjectMatrixPlugin.autoImport.virtualAxes
+
+lazy val scala212 = "2.12.12"
+lazy val scala213 = "2.13.3"
+
+val Play27 = PlayAxis.Value("2.7.4")
+val Play28 = PlayAxis.Value("2.8.1")
+
+val Akka25 = AkkaAxis.Value("2.5.23")
+val Akka26 = AkkaAxis.Value("2.6.8")
+
+lazy val akka = projectMatrix
+  .customRow(
+    scalaVersions = Seq(scala212),
+    axisValues = Seq(Akka25, VirtualAxis.jvm),
+    settings = Nil
+  )
+  .customRow(
+    scalaVersions = Seq(scala212, scala213),
+    axisValues = Seq(Akka26, VirtualAxis.jvm),
+    settings = Nil
+  )
+  .settings(
+    // e.g. libraryDependencies += "com.typesafe.akka" %% "akka-actor" % AkkaAxis.current.value.version,
+    moduleName := AkkaAxis.current.value.nameComponent,
+  )
+
+lazy val play = projectMatrix
+  .dependsOn(akka)
+  .customRow(
+    scalaVersions = Seq(scala212, scala213),
+    axisValues = Seq(Play27, Akka25, VirtualAxis.jvm),
+    settings = Nil
+  )
+  .customRow(
+    scalaVersions = Seq(scala213),
+    axisValues = Seq(Play28, Akka26, VirtualAxis.jvm),
+    settings = Nil
+  )
+  .settings(
+    // e.g. libraryDependencies += "com.typesafe.play" %% "play" % PlayAxis.current.value.version,
+    moduleName := PlayAxis.current.value.nameComponent,
+  )

--- a/src/sbt-test/projectMatrix/jvm-inner-class/project/InnerClassAxis.scala
+++ b/src/sbt-test/projectMatrix/jvm-inner-class/project/InnerClassAxis.scala
@@ -1,0 +1,28 @@
+import sbt.{Def, VirtualAxis}
+import sbtprojectmatrix.ProjectMatrixPlugin.autoImport.virtualAxes
+
+object AkkaAxis extends InnerClassAxis("akka")
+
+object PlayAxis extends InnerClassAxis("play")
+
+class InnerClassAxis(prefix: String) {
+
+  case class Value(version: String) extends VirtualAxis.WeakAxis {
+
+    private val majorMinor: String = version.split('.').take(2).mkString // e.g. 28
+
+    def nameComponent: String = s"$prefix$majorMinor" // e.g. play28
+
+    override def directorySuffix: String = s"-$nameComponent"
+
+    override def idSuffix: String = directorySuffix
+
+    override def toString: String = s"$nameComponent($version)"
+  }
+
+  def current = Def.setting {
+    virtualAxes.value.collectFirst {
+      case a: Value => a
+    }.get
+  }
+}

--- a/src/sbt-test/projectMatrix/jvm-inner-class/project/plugins.sbt
+++ b/src/sbt-test/projectMatrix/jvm-inner-class/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/projectMatrix/jvm-inner-class/test
+++ b/src/sbt-test/projectMatrix/jvm-inner-class/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
## Problem definition
This may not be a problem with sbt-projectmatrix at all. However, the scripted test demonstrates what I wanted to do, but failed in a surprising way. The project fails to load with:
```
[info] [error] no rows were found in akka matching ProjectRow(true, List(play27(2.7.4), akka25(2.5.23), PlatformAxis(jvm,JVM,jvm), ScalaVersionAxis(2.12.12,2.12))):
[info] [error] ProjectRow(true, List(akka25(2.5.23), PlatformAxis(jvm,JVM,jvm), ScalaVersionAxis(2.12.12,2.12)))
[info] [error] ProjectRow(true, List(akka26(2.6.8), PlatformAxis(jvm,JVM,jvm), ScalaVersionAxis(2.12.12,2.12)))
[info] [error] ProjectRow(true, List(akka26(2.6.8), PlatformAxis(jvm,JVM,jvm), ScalaVersionAxis(2.13.3,2.13)))
```

Note that `play27(2.7.4)` is a `WeakAxis`.

The problem seems to be that at compile time, the inner classes have different types, but at runtime, they `eq` each other. That makes [isStronglyCompatible](https://github.com/sbt/sbt-projectmatrix/blob/develop/src/main/scala/sbt/VirtualAxis.scala#L33) conclude (undesirably) that the "play" `WeakAxis` must have values of the same axis type defined in the "akka" project.

Slightly related, the same problem seems to exist with enums.
```
scala> object Apple extends Enumeration {
     |   val GrannySmith = Value
     | }
object Apple

scala> object Orange extends Enumeration {
     |   val Valencia = Value
     | }
object Orange

scala> Apple.GrannySmith.getClass eq Orange.Valencia.getClass
val res1: Boolean = true
```

## Workaround
sbt-projectmatrix works as expected if I redefine the axis class in each of the inner class instances.

```scala
object AkkaAxis extends CustomAxis("akka") {
  type V = AkkaAxis

  case class AkkaAxis(version: String) extends Value(version)
}

object PlayAxis extends CustomAxis("play") {
  type V = PlayAxis

  case class PlayAxis(version: String) extends Value(version)
}

abstract class CustomAxis(prefix: String) {
  type V
  // ...
}
```
The duplication is unsatisfying.

## Paths forward
I don't have a good suggestion for what could be used as an axis identifier instead of `weakAxis.getClass`, e.g. using a `TypeTag` seems difficult. Maybe `VirtualAxis` could expose an overridable `def axisIdentifier: Any = getClass`. This would not fix the problem of the shared class instance, but it would at least expose an escape hatch that could be used to eliminate the duplication.

Or perhaps there's a better workaround I missed that would make something like that unnecessary? WDYT?