### PR TITLE
Retrieve all projects with axes values from the ProjectMatrix

### DIFF
--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -121,6 +121,7 @@ sealed trait ProjectMatrix extends CompositeProject {
   def filterProjects(axisValues: Seq[VirtualAxis]): Seq[Project]
   def filterProjects(autoScalaLibrary: Boolean, axisValues: Seq[VirtualAxis]): Seq[Project]
   def finder(axisValues: VirtualAxis*): ProjectFinder
+  def findAll(): Map[Project, Seq[VirtualAxis]]
 
   // resolve to the closest match for the given row
   private[sbt] def resolveMatch(thatRow: ProjectMatrix.ProjectRow): ProjectReference
@@ -484,6 +485,11 @@ object ProjectMatrix {
 
     override def finder(axisValues: VirtualAxis*): ProjectFinder =
       new AxisBaseProjectFinder(axisValues.toSeq)
+
+    override def findAll(): Map[Project, Seq[VirtualAxis]] =
+      resolvedMappings.map { case(row, project) =>
+        project -> row.axisValues
+      }
 
     def copy(
         id: String = id,

--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -121,7 +121,7 @@ sealed trait ProjectMatrix extends CompositeProject {
   def filterProjects(axisValues: Seq[VirtualAxis]): Seq[Project]
   def filterProjects(autoScalaLibrary: Boolean, axisValues: Seq[VirtualAxis]): Seq[Project]
   def finder(axisValues: VirtualAxis*): ProjectFinder
-  def findAll(): Map[Project, Seq[VirtualAxis]]
+  def allProjects(): Seq[(Project, Seq[VirtualAxis])]
 
   // resolve to the closest match for the given row
   private[sbt] def resolveMatch(thatRow: ProjectMatrix.ProjectRow): ProjectReference
@@ -486,10 +486,10 @@ object ProjectMatrix {
     override def finder(axisValues: VirtualAxis*): ProjectFinder =
       new AxisBaseProjectFinder(axisValues.toSeq)
 
-    override def findAll(): Map[Project, Seq[VirtualAxis]] =
+    override def allProjects(): Seq[(Project, Seq[VirtualAxis])] =
       resolvedMappings.map { case(row, project) =>
         project -> row.axisValues
-      }
+      }.toSeq
 
     def copy(
         id: String = id,

--- a/src/sbt-test/projectMatrix/finder/build.sbt
+++ b/src/sbt-test/projectMatrix/finder/build.sbt
@@ -22,8 +22,8 @@ lazy val custom =
   )
 
 check := {
-  val coreResults: Map[Project, Set[VirtualAxis]] = core.findAll().mapValues(_.toSet)
-  val customResults: Map[Project, Set[VirtualAxis]] = custom.findAll().mapValues(_.toSet)
+  val coreResults: Map[Project, Set[VirtualAxis]] = core.allProjects().toMap.mapValues(_.toSet)
+  val customResults: Map[Project, Set[VirtualAxis]] = custom.allProjects().toMap.mapValues(_.toSet)
 
   val isJvm = VirtualAxis.jvm
   val isJs = VirtualAxis.js

--- a/src/sbt-test/projectMatrix/finder/build.sbt
+++ b/src/sbt-test/projectMatrix/finder/build.sbt
@@ -1,0 +1,45 @@
+lazy val scala213 = "2.13.3"
+lazy val scala212 = "2.12.12"
+lazy val check = taskKey[Unit]("")
+
+
+lazy val config12 = ConfigAxis("Config1_2", "config1.2")
+lazy val config13 = ConfigAxis("Config1_3", "config1.3")
+
+lazy val root = (project in file("."))
+  .aggregate((core.projectRefs ++ custom.projectRefs):_*)
+
+lazy val core = (projectMatrix in file("core"))
+  .jvmPlatform(scalaVersions = Seq(scala213, scala212))
+  .jsPlatform(scalaVersions = Seq(scala212))
+
+lazy val custom =
+  (projectMatrix in file("custom"))
+  .customRow(
+    scalaVersions = Seq(scala212),
+    axisValues = Seq(config13, VirtualAxis.jvm),
+    _.settings()
+  )
+
+check := {
+  val coreResults: Map[Project, Set[VirtualAxis]] = core.findAll().mapValues(_.toSet)
+  val customResults: Map[Project, Set[VirtualAxis]] = custom.findAll().mapValues(_.toSet)
+
+  val isJvm = VirtualAxis.jvm
+  val isJs = VirtualAxis.js
+  val is213 = VirtualAxis.scalaPartialVersion(scala213)
+  val is212 = VirtualAxis.scalaPartialVersion(scala212)
+
+  val coreSubProjects = Set(
+    core.jvm(scala213), core.jvm(scala212),
+    core.js(scala212)
+  )
+
+  assert(coreResults.keySet == coreSubProjects)
+  assert(coreResults(core.jvm(scala213)) == Set(isJvm, is213))
+  assert(coreResults(core.jvm(scala212)) == Set(isJvm, is212))
+  assert(coreResults(core.js(scala212)) == Set(isJs, is212))
+
+  assert(customResults.keySet == Set(custom.jvm(scala212)))
+  assert(customResults(custom.jvm(scala212)) == Set(isJvm, is212, config13))
+}

--- a/src/sbt-test/projectMatrix/finder/project/ConfigAxis.scala
+++ b/src/sbt-test/projectMatrix/finder/project/ConfigAxis.scala
@@ -1,0 +1,3 @@
+import sbt._
+
+case class ConfigAxis(idSuffix: String, directorySuffix: String) extends VirtualAxis.WeakAxis

--- a/src/sbt-test/projectMatrix/finder/project/plugins.sbt
+++ b/src/sbt-test/projectMatrix/finder/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.0")

--- a/src/sbt-test/projectMatrix/finder/test
+++ b/src/sbt-test/projectMatrix/finder/test
@@ -1,0 +1,2 @@
+> compile
+> check


### PR DESCRIPTION
Related to #48 

I think that's the bit I'm missing to implement a more general way of encoding a command matrix.

If this looks okay (should I add `jvmAll`, `jsAll` and `nativeAll` that just return a Seq[Project]?), I should have enough to experiment somewhere separately and hopefully come up with a good enough implementation to inline it in this plugin.