### PR TITLE
Publish to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-    tags:
-      - '*'
+    tags: ["*"]
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,13 +24,12 @@ jobs:
         sbt test packagedArtifacts
     - name: Release
       env:
-        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-        BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
         CI_CLEAN: clean
         CI_RELEASE: publishSigned
         CI_SONATYPE_RELEASE: version
       run: |
-        .github/decodekey.sh
         sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,6 @@ lazy val root = (project in file("."))
     name := "sbt-projectmatrix",
     pluginCrossBuild / sbtVersion := "1.2.8",
     scalacOptions := Seq("-deprecation", "-unchecked"),
-    publishMavenStyle := false,
-    bintrayRepository := "sbt-plugins",
-    publishTo := (bintray / publishTo).value,
     scriptedLaunchOpts := { scriptedLaunchOpts.value ++
       Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
     },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
-addSbtPlugin("org.foundweekends" %% "sbt-bintray" % "0.6.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.1.1")
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")


### PR DESCRIPTION
Closes #47 

What I'm doing here is basically copying the steps that I know worked for publishing a plugin to maven central with sbt-ci-release.

I think the decodekey.sh script can also be removed as the plugin does this step?