### PR TITLE
Fix configure function not being called on nativePlatform

### DIFF
--- a/src/main/scala/sbt/internal/ProjectMatrix.scala
+++ b/src/main/scala/sbt/internal/ProjectMatrix.scala
@@ -438,7 +438,7 @@ object ProjectMatrix {
       customRow(true, scalaVersions, VirtualAxis.native +: axisValues, project => enableScalaNativePlugin(project).settings(settings))
 
     override def nativePlatform(scalaVersions: Seq[String], axisValues: Seq[VirtualAxis], configure: Project => Project): ProjectMatrix =
-      customRow(true, scalaVersions, VirtualAxis.native +: axisValues, project => enableScalaNativePlugin(project))
+      customRow(true, scalaVersions, VirtualAxis.native +: axisValues, project => configure(enableScalaNativePlugin(project)))
 
     def nativePlugin(classLoader: ClassLoader): Try[AutoPlugin] = {
       import sbtprojectmatrix.ReflectionUtil._


### PR DESCRIPTION
This was missing, and shows up in not begin able to set up custom native dependencies as such:

```scala
    .jvmPlatform(Seq(Versions.Scala))
    .jsPlatform(Seq(Versions.Scala))
    .nativePlatform(
      Seq(Versions.Scala),
      Seq.empty,
        _.dependsOn(app.native(Versions.Scala)) // this has no effect
    )
```

## workaround until this is released

just add a dummy value and set dependencies manually.

```scala
lazy val set = tests.native(Versions.Scala).dependsOn(app.native(Versions.Scala))
```